### PR TITLE
added bbox filtering to 'tilekiln-generate area'

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ This reads a config file and generates vector tiles, saving them to the object s
 Usage: tilekiln-generate area [OPTIONS] CONFIG STORAGE
 
   Generates tiles for an area
+  You can provide bounding box using --bbox parameter e.g.: 14,49,24.03,54.86
 
 Options:
   -d, --dbname TEXT
@@ -54,6 +55,7 @@ Options:
   -s, --chunk-size INTEGER
   -z, --min-zoom INTEGER
   -Z, --max-zoom INTEGER
+  --bbox TEXT
   --help                     Show this message and exit.
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='tilekiln',
-    version='0.0.5',
+    version='0.0.6',
     author="Paul Norman",
     author_email="osm@paulnorman.ca",
     url="https://github.com/pnorman/tilekiln",
@@ -15,7 +15,8 @@ setup(
         'fs',
         'pyyaml',
         'jinja2',
-        'psycopg2'
+        'psycopg2',
+        'mercantile',
     ],
     entry_points={
         'console_scripts': ['tilekiln-generate=tilekiln.scripts.generate:cli',

--- a/tilekiln/scripts/generate.py
+++ b/tilekiln/scripts/generate.py
@@ -48,13 +48,33 @@ def area(config, storage, dbname, host, port, username, connections,
 
     bounding_box = tuple(map(float, bbox.split(',')))
     if len(bounding_box) != 4:
-        raise ValueError(f'Provided bounding box: "{bbox}" is invalid. It should have 4 elements separated by commas.')
-    if bounding_box[0] < -180 or bounding_box[0] > 180 or bounding_box[2] < -180 or bounding_box[2] > 180:
-        raise ValueError('Longitude cannot be lower than -180 or higher than 180.')
-    if bounding_box[1] < -90 or bounding_box[1] > 90 or bounding_box[3] < -90 or bounding_box[3] > 90:
-        raise ValueError('Latitude cannot be lower than -90 or higher than 90.')
+        raise ValueError(
+            f'Provided bounding box: "{bbox}" is invalid.' +
+            ' It should have 4 elements separated by commas.'
+        )
+    if any([
+        bounding_box[0] < -180,
+        bounding_box[0] > 180,
+        bounding_box[2] < -180,
+        bounding_box[2] > 180,
+    ]):
+        raise ValueError(
+            'Longitude cannot be lower than -180 or higher than 180.'
+        )
+    if any([
+        bounding_box[1] < -90,
+        bounding_box[1] > 90,
+        bounding_box[3] < -90,
+        bounding_box[3] > 90
+    ]):
+        raise ValueError(
+            'Latitude cannot be lower than -90 or higher than 90.'
+        )
 
-    tiles = [(tile.z, tile.x, tile.y) for tile in mercantile.tiles(*bounding_box, zoom_levels)]
+    tiles = [
+        (tile.z, tile.x, tile.y)
+        for tile in mercantile.tiles(*bounding_box, zoom_levels)
+    ]
 
     # Apply some heuristics to guess a chunk size
     if chunk_size is None:

--- a/tilekiln/scripts/generate.py
+++ b/tilekiln/scripts/generate.py
@@ -1,5 +1,7 @@
 import click
 import fs.osfs
+import mercantile
+
 import tilekiln.config
 import tilekiln.kiln
 import os
@@ -24,8 +26,9 @@ def cli():
 @click.option('-s', '--chunk-size', type=click.INT)
 @click.option('-z', '--min-zoom', type=click.INT)
 @click.option('-Z', '--max-zoom', type=click.INT)
+@click.option('--bbox', 'bbox', default='-180,-90,180,90')
 def area(config, storage, dbname, host, port, username, connections,
-         chunk_size, min_zoom, max_zoom):
+         chunk_size, min_zoom, max_zoom, bbox):
     '''Generates tiles for an area'''
     # Get the directory the config is in
     full_path = os.path.join(os.getcwd(), config)
@@ -41,9 +44,17 @@ def area(config, storage, dbname, host, port, username, connections,
 
     min_zoom = min_zoom or config.minzoom
     max_zoom = max_zoom or config.maxzoom
+    zoom_levels = [z for z in range(min_zoom, max_zoom + 1)]
 
-    tiles = [(z, x, y) for z in range(min_zoom, max_zoom + 1)
-             for x in range(2**z) for y in range(2**z)]
+    bounding_box = tuple(map(float, bbox.split(',')))
+    if len(bounding_box) != 4:
+        raise ValueError(f'Provided bounding box: "{bbox}" is invalid. It should have 4 elements separated by commas.')
+    if bounding_box[0] < -180 or bounding_box[0] > 180 or bounding_box[2] < -180 or bounding_box[2] > 180:
+        raise ValueError('Longitude cannot be lower than -180 or higher than 180.')
+    if bounding_box[1] < -90 or bounding_box[1] > 90 or bounding_box[3] < -90 or bounding_box[3] > 90:
+        raise ValueError('Latitude cannot be lower than -90 or higher than 90.')
+
+    tiles = [(tile.z, tile.x, tile.y) for tile in mercantile.tiles(*bounding_box, zoom_levels)]
 
     # Apply some heuristics to guess a chunk size
     if chunk_size is None:


### PR DESCRIPTION
issue #8 

adds --bbox parameter to 'tilekiln-generate area' utility which allows restricting generated tiles to smaller area
bbox is provided as a string with coordinates separated by commas e.g.: -180,-90,180,90 for the entire world (which is the default if no value provided)